### PR TITLE
Discounted revenue functionality

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -23,17 +23,28 @@ class Invoice < ApplicationRecord
           join items on items.id = invoice_items.item_id 
           join merchants on merchants.id = items.merchant_id 
           join bulk_discounts on merchants.id = bulk_discounts.merchant_id
-        where invoice_id = #{self.id} and invoice_items.quantity > bulk_discounts.quantity
+        where invoice_id = #{self.id} and invoice_items.quantity >= bulk_discounts.quantity
         group by invoice_items.id
         ) as discounts"
-    ).first
+    ).first.revenue
   end
 
   def standard_revenue
-    invoice_items.joins(:bulk_discounts).where("invoice_items.quantity < bulk_discounts.quantity").sum("invoice_items.unit_price * invoice_items.quantity")
+    merchant_id = self.invoice_items.first.item.merchant.id
+    Invoice.find_by_sql(
+      "select SUM(quantity * unit_price) as revenue from (	
+        select invoice_items.id, invoice_items.quantity, invoice_items.unit_price from invoices 
+            join invoice_items on invoices.id = invoice_items.invoice_id 
+            join items on items.id = invoice_items.item_id 
+            join merchants on merchants.id = items.merchant_id 
+            join bulk_discounts on merchants.id = bulk_discounts.merchant_id
+          where invoices.id = #{self.id} and invoice_items.quantity < (select MIN(quantity) from bulk_discounts where merchant_id = #{merchant_id})
+          group by invoice_items.id
+          ) as no_discount"
+    ).first.revenue
   end
 
   def total_discounted_revenue
-    self.discounted_revenue.revenue + self.standard_revenue
+    (self.discounted_revenue.to_f + self.standard_revenue.to_f).round(2)
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -32,4 +32,8 @@ class Invoice < ApplicationRecord
   def standard_revenue
     invoice_items.joins(:bulk_discounts).where("invoice_items.quantity < bulk_discounts.quantity").sum("invoice_items.unit_price * invoice_items.quantity")
   end
+
+  def total_discounted_revenue
+    self.discounted_revenue.revenue + self.standard_revenue
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,10 +7,29 @@ class Invoice < ApplicationRecord
   has_many :invoice_items
   has_many :items, through: :invoice_items
   has_many :merchants, through: :items
+  has_many :bulk_discounts, through: :merchants
 
   enum status: [:cancelled, :in_progress, :completed]
 
   def total_revenue
     invoice_items.sum("unit_price * quantity")
+  end
+
+  def discounted_revenue
+    Invoice.find_by_sql(
+      "select SUM(quantity * unit_price * (1.0 - biggest_discount / 100.0)) as revenue from (
+        select invoice_items.id, invoice_items.quantity, invoice_items.unit_price, MAX(bulk_discounts.percent) as biggest_discount from invoices 
+          join invoice_items on invoices.id = invoice_items.invoice_id 
+          join items on items.id = invoice_items.item_id 
+          join merchants on merchants.id = items.merchant_id 
+          join bulk_discounts on merchants.id = bulk_discounts.merchant_id
+        where invoice_id = #{self.id} and invoice_items.quantity > bulk_discounts.quantity
+        group by invoice_items.id
+        ) as discounts"
+    ).first
+  end
+
+  def standard_revenue
+    invoice_items.joins(:bulk_discounts).where("invoice_items.quantity < bulk_discounts.quantity").sum("invoice_items.unit_price * invoice_items.quantity")
   end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -7,6 +7,8 @@ class InvoiceItem < ApplicationRecord
 
   belongs_to :invoice
   belongs_to :item
+  has_one :merchant, through: :item
+  has_many :bulk_discounts, through: :merchant
 
   enum status: [:pending, :packaged, :shipped]
 

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -22,6 +22,6 @@ class InvoiceItem < ApplicationRecord
       .select("bulk_discounts.id")
       .where("#{self.quantity} >= bulk_discounts.quantity")
       .order("bulk_discounts.percent DESC")
-      .limit(1).first.id
+      .limit(1).first
   end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -16,4 +16,12 @@ class InvoiceItem < ApplicationRecord
     invoice_ids = InvoiceItem.where("status = 0 OR status = 1").pluck(:invoice_id)
     Invoice.order(created_at: :asc).find(invoice_ids)
   end
+
+  def discount_id
+    bulk_discounts
+      .select("bulk_discounts.id")
+      .where("#{self.quantity} >= bulk_discounts.quantity")
+      .order("bulk_discounts.percent DESC")
+      .limit(1).first.id
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,6 +7,7 @@ class Item < ApplicationRecord
   has_many :invoice_items
   has_many :invoices, through: :invoice_items
   belongs_to :merchant
+  has_many :bulk_discounts, through: :merchant
 
   enum status: [:disabled, :enabled]
 

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -14,6 +14,7 @@
       <% end %>
   <p>Created on: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %>
   <p>Total Revenue: <%= number_to_currency(@invoice.total_revenue) %>
+  <p>Discounted Revenue: <%= number_to_currency(@invoice.total_discounted_revenue) %></p>
 
   <h4>Customer:</h4>
     <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %><br>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -27,6 +27,7 @@
         <th class="th1">Quantity</th>
         <th class="th1">Unit Price</th>
         <th class="th1">Status</th>
+        <th class="th1">Applied Discount</th>
       </tr>
     </thead>
 
@@ -43,6 +44,7 @@
                 <%= f.submit 'Update Invoice' %>
               <% end %>
               </td>
+            <td style="text-align:center"><%= i.discount_id ? link_to("View Applied Discount", merchant_bulk_discount_path(@merchant, i.discount_id.id)) : "" %></td>
           </tr>
         </section>
       <% end %>

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -12,6 +12,7 @@
 
   <p> Created on: <%= @invoice.created_at.strftime("%A, %B %-d, %Y") %></p>
   <p>Total Revenue: <%= @invoice.total_revenue %></p>
+  <p>Total Discounted Revenue: <%= @invoice.total_discounted_revenue %></p>
 
 
   <h4>Customer:</h4>

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -17,6 +17,8 @@ describe "Admin Invoices Index Page" do
     @ii_2 = InvoiceItem.create!(invoice_id: @i1.id, item_id: @item_2.id, quantity: 6, unit_price: 1, status: 1)
     @ii_3 = InvoiceItem.create!(invoice_id: @i2.id, item_id: @item_2.id, quantity: 87, unit_price: 12, status: 2)
 
+    BulkDiscount.create!(percent: 10, quantity: 8, merchant_id: @m1.id)
+
     visit admin_invoice_path(@i1)
   end
 
@@ -68,5 +70,9 @@ describe "Admin Invoices Index Page" do
       expect(current_path).to eq(admin_invoice_path(@i1))
       expect(@i1.status).to eq("completed")
     end
+  end
+
+  it "shows the discounted revenue separately from the total revenue for the invoice" do
+    expect(page).to have_content("$#{@i1.total_discounted_revenue}")
   end
 end

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -51,6 +51,8 @@ RSpec.describe "invoices show" do
     @transaction6 = Transaction.create!(credit_card_number: 879799, result: 0, invoice_id: @invoice_6.id)
     @transaction7 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_7.id)
     @transaction8 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_8.id)
+
+    # BulkDiscount.create!(percent: 10, quantity: 20, merchant_id: @merchant1.id)
   end
 
   it "shows the invoice information" do
@@ -103,7 +105,7 @@ RSpec.describe "invoices show" do
   it "shows the discounted revenue separately from the total revenue for the invoice" do
     visit merchant_invoice_path(@merchant1, @invoice_1)
     
-    expect(page).to have_content(@invoice_1.discounted_revenue)
+    expect(page).to have_content(@invoice_1.discounted_revenue.revenue)
   end
 
 end

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "invoices show" do
     @transaction7 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_7.id)
     @transaction8 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_8.id)
 
-    # BulkDiscount.create!(percent: 10, quantity: 20, merchant_id: @merchant1.id)
+    BulkDiscount.create!(percent: 10, quantity: 20, merchant_id: @merchant1.id)
   end
 
   it "shows the invoice information" do
@@ -105,7 +105,7 @@ RSpec.describe "invoices show" do
   it "shows the discounted revenue separately from the total revenue for the invoice" do
     visit merchant_invoice_path(@merchant1, @invoice_1)
     
-    expect(page).to have_content(@invoice_1.discounted_revenue.revenue)
+    expect(page).to have_content(@invoice_1.discounted_revenue)
   end
 
 end

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -100,4 +100,10 @@ RSpec.describe "invoices show" do
     end
   end
 
+  it "shows the discounted revenue separately from the total revenue for the invoice" do
+    visit merchant_invoice_path(@merchant1, @invoice_1)
+    
+    expect(page).to have_content(@invoice_1.discounted_revenue)
+  end
+
 end

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "invoices show" do
     @transaction7 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_7.id)
     @transaction8 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_8.id)
 
-    BulkDiscount.create!(percent: 10, quantity: 20, merchant_id: @merchant1.id)
+    @discount_1 = BulkDiscount.create!(percent: 10, quantity: 8, merchant_id: @merchant1.id)
   end
 
   it "shows the invoice information" do
@@ -105,7 +105,15 @@ RSpec.describe "invoices show" do
   it "shows the discounted revenue separately from the total revenue for the invoice" do
     visit merchant_invoice_path(@merchant1, @invoice_1)
     
-    expect(page).to have_content(@invoice_1.discounted_revenue)
+    expect(page).to have_content(@invoice_1.total_discounted_revenue)
+  end
+
+  it "has a link beside each item that was discounted to the bulk discount that was applied" do
+    visit merchant_invoice_path(@merchant1, @invoice_1)
+
+    within("#the-status-#{@ii_1.id}") do
+      expect(page).to have_link("View Applied Discount", href: "/merchants/#{@merchant1.id}/bulk_discounts/#{@discount_1.id}")
+    end
   end
 
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe InvoiceItem, type: :model do
   describe "relationships" do
     it { should belong_to :invoice }
     it { should belong_to :item }
+    it { should have_one(:merchant).through(:item) }
+    it { should have_many(:bulk_discounts).through(:merchant) }
   end
 
   describe "class methods" do
@@ -54,8 +56,8 @@ RSpec.describe InvoiceItem, type: :model do
         @discount_1 = BulkDiscount.create!(percent: 10, quantity: 5, merchant_id: @m1.id)
         @discount_2 = BulkDiscount.create!(percent: 20, quantity: 10, merchant_id: @m1.id)
 
-        expect(@ii_1.discount_id).to eq(@discount_2.id)
-        expect(@ii_2.discount_id).to eq(@discount_1.id)
+        expect(@ii_1.discount_id.id).to eq(@discount_2.id)
+        expect(@ii_2.discount_id.id).to eq(@discount_1.id)
       end
     end
   end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -39,4 +39,24 @@ RSpec.describe InvoiceItem, type: :model do
       expect(InvoiceItem.incomplete_invoices).to eq([@i1, @i3])
     end
   end
+
+  describe "instance methods" do
+    describe "#discount_id" do
+      it "returns information related to the discount applied to an invoice_item" do
+        @m1 = Merchant.create!(name: 'Merchant 1')
+        @c1 = Customer.create!(first_name: 'Bilbo', last_name: 'Baggins')
+        @item_1 = Item.create!(name: 'Shampoo', description: 'This washes your hair', unit_price: 10, merchant_id: @m1.id)
+        @item_2 = Item.create!(name: 'Conditioner', description: 'This makes your hair shiny', unit_price: 8, merchant_id: @m1.id)
+        @item_3 = Item.create!(name: 'Brush', description: 'This takes out tangles', unit_price: 5, merchant_id: @m1.id)
+        @i1 = Invoice.create!(customer_id: @c1.id, status: 2)
+        @ii_1 = InvoiceItem.create!(invoice_id: @i1.id, item_id: @item_1.id, quantity: 10, unit_price: 10, status: 0)
+        @ii_2 = InvoiceItem.create!(invoice_id: @i1.id, item_id: @item_2.id, quantity: 6, unit_price: 8, status: 0)
+        @discount_1 = BulkDiscount.create!(percent: 10, quantity: 5, merchant_id: @m1.id)
+        @discount_2 = BulkDiscount.create!(percent: 20, quantity: 10, merchant_id: @m1.id)
+
+        expect(@ii_1.discount_id).to eq(@discount_2.id)
+        expect(@ii_2.discount_id).to eq(@discount_1.id)
+      end
+    end
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Invoice, type: :model do
         @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 1, unit_price: 10, status: 1)
         BulkDiscount.create!(percent: 10, quantity: 5, merchant_id: @merchant1.id)
 
-        expect(@invoice_1.discounted_revenue.revenue).to eq(81.0)
+        expect(@invoice_1.discounted_revenue).to eq(81.0)
       end
     end
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -23,5 +23,20 @@ RSpec.describe Invoice, type: :model do
 
       expect(@invoice_1.total_revenue).to eq(100)
     end
+
+    describe "#discounted_revenue" do
+      it "returns the discounted revenue for an invoice" do #only handles 1 discount for now
+        @merchant1 = Merchant.create!(name: 'Hair Care')
+        @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
+        @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+        @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+        @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
+        @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
+        @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 1, unit_price: 10, status: 1)
+        BulkDiscount.create!(percent: 10, quantity: 5, merchant_id: @merchant1.id)
+
+        expect(@invoice_1.discounted_revenue).to eq(91)
+      end
+    end
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -5,12 +5,16 @@ RSpec.describe Invoice, type: :model do
     it { should validate_presence_of :status }
     it { should validate_presence_of :customer_id }
   end
+  
   describe "relationships" do
     it { should belong_to :customer }
+    it { should have_many :transactions}
+    it { should have_many :invoice_items }
     it { should have_many(:items).through(:invoice_items) }
     it { should have_many(:merchants).through(:items) }
-    it { should have_many :transactions}
+    it { should have_many(:bulk_discounts).through(:merchants) }
   end
+
   describe "instance methods" do
     it "total_revenue" do
       @merchant1 = Merchant.create!(name: 'Hair Care')

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Invoice, type: :model do
     end
 
     describe "#discounted_revenue" do
-      it "returns the discounted revenue for an invoice" do
+      it "returns only the discounted revenue for an invoice" do
         @merchant1 = Merchant.create!(name: 'Hair Care')
         @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
         @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
@@ -40,7 +40,7 @@ RSpec.describe Invoice, type: :model do
     end
 
     describe "#standard_revenue" do
-      it "returns the standard revenue for an invoice" do
+      it "returns only the standard revenue for an invoice" do
         @merchant1 = Merchant.create!(name: 'Hair Care')
         @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
         @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
@@ -51,6 +51,21 @@ RSpec.describe Invoice, type: :model do
         BulkDiscount.create!(percent: 10, quantity: 5, merchant_id: @merchant1.id)
 
         expect(@invoice_1.standard_revenue).to eq(10.0)
+      end
+    end
+
+    describe "#total_discounted_revenue" do
+      it "returns the total revenue for an invoice, accounting for the discounted revenue" do
+        @merchant1 = Merchant.create!(name: 'Hair Care')
+        @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
+        @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+        @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+        @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
+        @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
+        @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 1, unit_price: 10, status: 1)
+        BulkDiscount.create!(percent: 10, quantity: 5, merchant_id: @merchant1.id)
+
+        expect(@invoice_1.total_discounted_revenue).to eq(91.0)
       end
     end
   end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Invoice, type: :model do
     end
 
     describe "#discounted_revenue" do
-      it "returns the discounted revenue for an invoice" do #only handles 1 discount for now
+      it "returns the discounted revenue for an invoice" do
         @merchant1 = Merchant.create!(name: 'Hair Care')
         @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
         @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
@@ -35,7 +35,22 @@ RSpec.describe Invoice, type: :model do
         @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 1, unit_price: 10, status: 1)
         BulkDiscount.create!(percent: 10, quantity: 5, merchant_id: @merchant1.id)
 
-        expect(@invoice_1.discounted_revenue).to eq(91)
+        expect(@invoice_1.discounted_revenue.revenue).to eq(81.0)
+      end
+    end
+
+    describe "#standard_revenue" do
+      it "returns the standard revenue for an invoice" do
+        @merchant1 = Merchant.create!(name: 'Hair Care')
+        @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id, status: 1)
+        @item_8 = Item.create!(name: "Butterfly Clip", description: "This holds up your hair but in a clip", unit_price: 5, merchant_id: @merchant1.id)
+        @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+        @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2, created_at: "2012-03-27 14:54:09")
+        @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 9, unit_price: 10, status: 2)
+        @ii_11 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_8.id, quantity: 1, unit_price: 10, status: 1)
+        BulkDiscount.create!(percent: 10, quantity: 5, merchant_id: @merchant1.id)
+
+        expect(@invoice_1.standard_revenue).to eq(10.0)
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Item, type: :model do
     it { should validate_presence_of :merchant_id }
   end
   describe "relationships" do
+    it { should have_many :invoice_items }
     it { should have_many(:invoices).through(:invoice_items) }
     it { should belong_to :merchant }
     it { should have_many(:bulk_discounts).through(:merchant) }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Item, type: :model do
   describe "relationships" do
     it { should have_many(:invoices).through(:invoice_items) }
     it { should belong_to :merchant }
+    it { should have_many(:bulk_discounts).through(:merchant) }
   end
   describe "instance methods" do
     it "best day" do


### PR DESCRIPTION
This PR handles all of the query and view updates for displaying discounted revenue on invoices.

This was done via two separate queries - one for the revenue from ONLY discounted items, and another for the revenue from ONLY non-discounted items. Combined together, they produce the total discounted revenue.